### PR TITLE
Pin build-essential so spp can build

### DIFF
--- a/spp/1.13/Dockerfile
+++ b/spp/1.13/Dockerfile
@@ -3,7 +3,7 @@ FROM r-base:3.2.4
 RUN apt-get update && apt-get install -y \
   libboost-all-dev \
   curl \
-  build-essential \
+  build-essential=12.2 \
   libncurses-dev \
   zlib1g-dev \
   gawk


### PR DESCRIPTION
The Dockerfile was pulling in build-essential 12.3.
Fixes #23 