### PR TITLE
Detects changes to the latest symlink and pushes updated tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - deploy:
           name: Deploy Docker Images
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "${DEPLOY_BRANCH}" ]; then
               docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
               ./deploy-ci.sh
             fi

--- a/build-ci.sh
+++ b/build-ci.sh
@@ -4,20 +4,33 @@
 #
 # Builds docker images when a commit to the repo changes a Dockerfile
 # Tags versioned images as `latest` when a symlink `latest` points to the version's directory
+#
+# Detecting changes to build is done using git diff and comparing filenames.
+# The build's checked-out branch causes the comparison to happen in one of two ways:
+#
+# 1. When building (and deploying) the deploy branch (typically 'master'), the script
+#    expects the HEAD commit to be a merge commit (from merging a pull request).
+#    If it is not a merge, the build fails.
+#    Otherwise, the parents of the merge are compared to get the changed files.
+#    Using this approach, we test the changes that are merged into the deploy branch.
+#
+# 2. When building other branches, the script compares the branch with the deploy
+#    branch (e.g. 'master'). Any files changed between the two branches are considered
+#    for building. This way, we can trigger rebuilding a docker image without adding
+#    irrelevant comments or blank lines to Dockerfiles.
 
 set -e
 source functions.sh
-# Docker Hub organization to prefix on built docker images should be in DOCKERHUB_ORG
+# Check that the Docker Hub organization to use is in the DOCKERHUB_ORG variable
 check_org
-# We only want to build images when a Dockerfile changes, so we start with a list of
-# changed paths and look for <tool>/<version>/Dockerfile
-# To get the list of changed paths, we use `git diff-tree`, which returns nothing for merge commits
-# So we find the most recent commit that's not a merge.
-sha=$(last_nonmerge_commit_sha)
+# Check that the branch to use for deploying (typically 'master') is in the DEPLOY_BRANCH variable
+check_deploy_branch
+# Get the range of commits to compare for detecting changed files
+compare_range=$(get_compare_range)
 # Get a list of changed paths in the repo to look for <tool>/<version>/Dockerfile
-paths=$(changed_paths_in_commit $sha)
+paths=$(changed_paths_in_range $compare_range)
 # Print out what changes are being considered
-print_changed "$sha" "$paths"
+print_changed "$compare_range" "$paths"
 # Loop through the changed files and build Docker images for any that match
 # <tool>/<version>/Dockerfile. If none found, prints a message indicating so.
 build_images "$DOCKERHUB_ORG" "$paths"

--- a/build-ci.sh
+++ b/build-ci.sh
@@ -28,7 +28,7 @@ check_deploy_branch
 # Get the range of commits to compare for detecting changed files
 compare_range=$(get_compare_range)
 # Get a list of changed paths in the repo to look for <tool>/<version>/Dockerfile
-paths=$(changed_paths_in_range $compare_range)
+paths=$(changed_paths_in_range "$compare_range")
 # Print out what changes are being considered
 print_changed "$compare_range" "$paths"
 # Loop through the changed files and build Docker images for any that match

--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -2,14 +2,14 @@
 
 # CI Deploy Script for GCB-Dockerfiles
 #
-# Expects to be authenticated to Docker Hub and only run from master branch
+# Expects to be authenticated to Docker Hub and only run from DEPLOY_BRANCH
 # Pushes Docker images and tags to Docker Hub when build-ci.sh has built the image
 
 set -e
 source functions.sh
 # See build-ci.sh for explanation of these conventions/rules
 check_org
-sha=$(last_nonmerge_commit_sha)
-paths=$(changed_paths_in_commit $sha)
+check_deploy_branch
+compare_range=$(get_compare_range)
+paths=$(changed_paths_in_range $compare_range)
 push_images "$DOCKERHUB_ORG" "$paths"
-

--- a/deploy-ci.sh
+++ b/deploy-ci.sh
@@ -11,5 +11,5 @@ source functions.sh
 check_org
 check_deploy_branch
 compare_range=$(get_compare_range)
-paths=$(changed_paths_in_range $compare_range)
+paths=$(changed_paths_in_range "$compare_range")
 push_images "$DOCKERHUB_ORG" "$paths"

--- a/functions.sh
+++ b/functions.sh
@@ -49,7 +49,8 @@ function get_compare_range() {
   else
     # Not on the deploy branch (e.g. master)
     # When not on the deploy branch, always compare with the deploy branch
-    range_start="$DEPLOY_BRANCH"
+    # Circle resets master to the tested commit, so we have to use origin/master
+    range_start="origin/$DEPLOY_BRANCH"
     range_end="HEAD"
   fi
   echo "$range_start $range_end"

--- a/functions.sh
+++ b/functions.sh
@@ -24,7 +24,7 @@ function check_deploy_branch() {
     echo "Please ensure DEPLOY_BRANCH is set to the name of the git branch that should be considered for deploying, typically 'master'";
     exit 1;
   else
-    echo "Using Deploy branch org as $DEPLOY_BRANCH..."
+    echo "Using Deploy branch as $DEPLOY_BRANCH..."
   fi
   current_branch=$(current_branch_name)
   if [[ "$current_branch" == "$DEPLOY_BRANCH" ]]; then

--- a/functions.sh
+++ b/functions.sh
@@ -86,7 +86,7 @@ function tag_docker_cmd() {
   tool=$2
   src=$3
   tag=$4
-  echo "docker tag $owner/$tool:$version $owner/$tool:$tag"
+  echo "docker tag $owner/$tool:$src $owner/$tool:$tag"
 }
 
 # Given a docker repo owner, image name, and version, produce a command that returns the image id if it exists locally
@@ -141,6 +141,7 @@ function build_images() {
     IFS='/' read -r -a f <<< "$changed_path"
     tool="${f[0]}"
     version="${f[1]}"
+    filename="${f[2]}"
     if [[ -L "$changed_path" && "$filename" == "" && "$version" == "latest" ]]; then
       attempted_build="1"
       # The changed file is a symlink called latest, e.g. "fastqc/latest"
@@ -189,6 +190,7 @@ function push_images() {
     IFS='/' read -r -a f <<< "$changed_path"
     tool="${f[0]}"
     version="${f[1]}"
+    filename="${f[2]}"
     if [[ -L "$changed_path" && "$filename" == "" && "$version" == "latest" ]]; then
       attempted_push="1"
       # The changed file is a symlink called latest, e.g. "fastqc/latest"

--- a/functions.sh
+++ b/functions.sh
@@ -13,7 +13,8 @@ function get_num_parents() {
 # Given a range, produce the list of file paths changed
 function changed_paths_in_range() {
   compare_range=$1
-  git diff --name-only $compare_range
+  # diff-filter=d excludes deleted files
+  git diff --name-only --diff-filter=d $compare_range
 }
 
 # Check if DEPLOY_BRANCH is set and current branch can be tested


### PR DESCRIPTION
- Looks for committed changes to `latest` after building/pushing to ensure we're tagging the most recent build
- Pulls images locally for tagging if they do not exist (e.g. were not just built)